### PR TITLE
新增民宿业务页面

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,14 @@
 {
-  "pages": ["pages/home/home", "pages/category/index", "pages/cart/index", "pages/usercenter/index"],
+  "pages": [
+    "pages/home/home",
+    "pages/house/list/index",
+    "pages/house/detail/index",
+    "pages/contact/index",
+    "pages/about/index",
+    "pages/category/index",
+    "pages/cart/index",
+    "pages/usercenter/index"
+  ],
   "subpackages": [
     {
       "root": "pages/user",

--- a/model/house.js
+++ b/model/house.js
@@ -1,0 +1,30 @@
+import { cdnBase } from '../config/index';
+
+const images = [
+  `${cdnBase}/goods/nz-08a.png`,
+  `${cdnBase}/goods/nz-08b.png`,
+  `${cdnBase}/goods/nz-17a.png`,
+  `${cdnBase}/goods/nz-17b.png`,
+  `${cdnBase}/goods/nz-05a.png`,
+  `${cdnBase}/goods/nz-05b.png`,
+];
+
+const houses = Array.from({ length: 24 }, (_, i) => {
+  const idx = i % images.length;
+  return {
+    id: String(i + 1),
+    title: `特色民宿${i + 1}`,
+    desc: '干净整洁，舒适温馨',
+    image: images[idx],
+    images: [images[idx]],
+  };
+});
+
+export function getHousesList(pageIndex = 1, pageSize = 24) {
+  const start = (pageIndex - 1) * pageSize;
+  return houses.slice(start, start + pageSize);
+}
+
+export function getHouseDetail(id) {
+  return houses.find((item) => item.id === id);
+}

--- a/model/swiper.js
+++ b/model/swiper.js
@@ -25,7 +25,7 @@
 //   },
 // ];
 
-const images = [
+const baseImages = [
   'https://tdesign.gtimg.com/miniprogram/template/retail/home/v2/banner1.png',
   'https://tdesign.gtimg.com/miniprogram/template/retail/home/v2/banner2.png',
   'https://tdesign.gtimg.com/miniprogram/template/retail/home/v2/banner3.png',
@@ -33,6 +33,8 @@ const images = [
   'https://tdesign.gtimg.com/miniprogram/template/retail/home/v2/banner5.png',
   'https://tdesign.gtimg.com/miniprogram/template/retail/home/v2/banner6.png',
 ];
+
+const images = Array.from({ length: 25 }, (_, i) => baseImages[i % baseImages.length]);
 
 export function genSwiperImageList() {
   return images;

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -1,0 +1,7 @@
+Page({
+  data: {
+    images: [
+      'https://tdesign.gtimg.com/miniprogram/template/retail/goods/nz-17a.png'
+    ]
+  }
+});

--- a/pages/about/index.json
+++ b/pages/about/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "关于我们"
+}

--- a/pages/about/index.wxml
+++ b/pages/about/index.wxml
@@ -1,0 +1,9 @@
+<view class="wrap">
+  <view class="text">民宿风格、环境特色、经营理念等文字</view>
+  <view class="contact">
+    微信：hotel123
+    <br />
+    电话：13800138000
+  </view>
+  <image wx:for="{{images}}" wx:key="index" class="pic" src="{{item}}" mode="aspectFill" />
+</view>

--- a/pages/about/index.wxss
+++ b/pages/about/index.wxss
@@ -1,0 +1,17 @@
+.wrap {
+  padding: 24rpx;
+}
+.text {
+  font-size: 28rpx;
+  color: #333;
+}
+.contact {
+  margin-top: 20rpx;
+  font-size: 24rpx;
+  color: #666;
+}
+.pic {
+  width: 100%;
+  height: 200rpx;
+  margin-top: 20rpx;
+}

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -1,0 +1,13 @@
+Page({
+  data: {
+    wechat: 'hotel123',
+    phone: '13800138000',
+    qr: 'https://tdesign.gtimg.com/miniprogram/template/retail/avatar/avatar1.png'
+  },
+  copyWechat() {
+    wx.setClipboardData({ data: this.data.wechat });
+  },
+  call() {
+    wx.makePhoneCall({ phoneNumber: this.data.phone });
+  }
+});

--- a/pages/contact/index.json
+++ b/pages/contact/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "联系客服"
+}

--- a/pages/contact/index.wxml
+++ b/pages/contact/index.wxml
@@ -1,0 +1,11 @@
+<view class="wrap">
+  <view class="wechat">
+    微信号：{{wechat}}
+    <button size="mini" type="primary" bindtap="copyWechat">复制</button>
+  </view>
+  <view class="phone">
+    <button type="primary" bindtap="call">拨打电话</button>
+  </view>
+  <image class="qr" src="{{qr}}" mode="aspectFill" />
+  <view class="tip">长按保存添加</view>
+</view>

--- a/pages/contact/index.wxss
+++ b/pages/contact/index.wxss
@@ -1,0 +1,19 @@
+.wrap {
+  padding: 24rpx;
+  text-align: center;
+}
+.qr {
+  width: 200rpx;
+  height: 200rpx;
+  margin-top: 20rpx;
+}
+.tip {
+  font-size: 24rpx;
+  color: #666;
+}
+.wechat {
+  margin-top: 20rpx;
+}
+.phone {
+  margin-top: 20rpx;
+}

--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -1,13 +1,10 @@
 import { fetchHome } from '../../services/home/home';
-import { fetchGoodsList } from '../../services/good/fetchGoods';
-import Toast from 'tdesign-miniprogram/toast/index';
+import { fetchHouseList } from '../../services/house/house';
 
 Page({
   data: {
     imgSrcs: [],
-    tabList: [],
-    goodsList: [],
-    goodsListLoadStatus: 0,
+    houseList: [],
     pageLoading: false,
     current: 1,
     autoplay: true,
@@ -17,13 +14,9 @@ Page({
     swiperImageProps: { mode: 'scaleToFill' },
   },
 
-  goodListPagination: {
+  houseListPagination: {
     index: 0,
-    num: 20,
-  },
-
-  privateData: {
-    tabIndex: 0,
+    num: 24,
   },
 
   onShow() {
@@ -32,12 +25,6 @@ Page({
 
   onLoad() {
     this.init();
-  },
-
-  onReachBottom() {
-    if (this.data.goodsListLoadStatus === 0) {
-      this.loadGoodsList();
-    }
   },
 
   onPullDownRefresh() {
@@ -54,72 +41,32 @@ Page({
     this.setData({
       pageLoading: true,
     });
-    fetchHome().then(({ swiper, tabList }) => {
+    fetchHome().then(({ swiper }) => {
       this.setData({
-        tabList,
         imgSrcs: swiper,
         pageLoading: false,
       });
-      this.loadGoodsList(true);
+      this.loadHouseList();
     });
   },
 
-  tabChangeHandle(e) {
-    this.privateData.tabIndex = e.detail;
-    this.loadGoodsList(true);
+  async loadHouseList() {
+    const list = await fetchHouseList();
+    this.setData({
+      houseList: list,
+    });
   },
 
-  onReTry() {
-    this.loadGoodsList();
-  },
 
-  async loadGoodsList(fresh = false) {
-    if (fresh) {
-      wx.pageScrollTo({
-        scrollTop: 0,
-      });
-    }
-
-    this.setData({ goodsListLoadStatus: 1 });
-
-    const pageSize = this.goodListPagination.num;
-    let pageIndex = this.privateData.tabIndex * pageSize + this.goodListPagination.index + 1;
-    if (fresh) {
-      pageIndex = 0;
-    }
-
-    try {
-      const nextList = await fetchGoodsList(pageIndex, pageSize);
-      this.setData({
-        goodsList: fresh ? nextList : this.data.goodsList.concat(nextList),
-        goodsListLoadStatus: 0,
-      });
-
-      this.goodListPagination.index = pageIndex;
-      this.goodListPagination.num = pageSize;
-    } catch (err) {
-      this.setData({ goodsListLoadStatus: 3 });
-    }
-  },
-
-  goodListClickHandle(e) {
-    const { index } = e.detail;
-    const { spuId } = this.data.goodsList[index];
+  houseClickHandle(e) {
+    const { id } = e.currentTarget.dataset;
     wx.navigateTo({
-      url: `/pages/goods/details/index?spuId=${spuId}`,
-    });
-  },
-
-  goodListAddCartHandle() {
-    Toast({
-      context: this,
-      selector: '#t-toast',
-      message: '点击加入购物车',
+      url: `/pages/house/detail/index?id=${id}`,
     });
   },
 
   navToSearchPage() {
-    wx.navigateTo({ url: '/pages/goods/search/index' });
+    wx.navigateTo({ url: '/pages/house/list/index' });
   },
 
   navToActivityDetail({ detail }) {

--- a/pages/home/home.json
+++ b/pages/home/home.json
@@ -10,10 +10,6 @@
     "t-swiper-nav": "tdesign-miniprogram/swiper-nav/swiper-nav",
     "t-image": "/components/webp-image/index",
     "t-icon": "tdesign-miniprogram/icon/icon",
-    "t-toast": "tdesign-miniprogram/toast/toast",
-    "t-tabs": "tdesign-miniprogram/tabs/tabs",
-    "t-tab-panel": "tdesign-miniprogram/tab-panel/tab-panel",
-    "goods-list": "/components/goods-list/index",
-    "load-more": "/components/load-more/index"
+    "t-toast": "tdesign-miniprogram/toast/toast"
   }
 }

--- a/pages/home/home.wxml
+++ b/pages/home/home.wxml
@@ -2,17 +2,6 @@
   <t-loading theme="circular" size="40rpx" text="加载中..." inherit-color />
 </view>
 <view class="home-page-header">
-  <view class="search" bind:tap="navToSearchPage">
-    <t-search
-      t-class-input="t-search__input"
-      t-class-input-container="t-search__input-container"
-      placeholder="iphone 13 火热发售中"
-      leftIcon=""
-      disabled
-    >
-      <t-icon slot="left-icon" prefix="wr" name="search" size="40rpx" color="#bbb" />
-    </t-search>
-  </view>
   <view class="swiper-wrap">
     <t-swiper
       wx:if="{{imgSrcs.length > 0}}"
@@ -23,36 +12,23 @@
       navigation="{{navigation}}"
       imageProps="{{swiperImageProps}}"
       list="{{imgSrcs}}"
-      bind:click="navToActivityDetail"
     />
   </view>
 </view>
 <view class="home-page-container">
-  <view class="home-page-tabs">
-    <t-tabs
-      t-class="t-tabs"
-      t-class-active="tabs-external__active"
-      t-class-item="tabs-external__item"
-      defaultValue="{{0}}"
-      space-evenly="{{false}}"
-      bind:change="tabChangeHandle"
+  <view class="house-grid">
+    <view
+      class="house-card"
+      wx:for="{{houseList}}"
+      wx:key="id"
+      data-id="{{item.id}}"
+      bind:tap="houseClickHandle"
     >
-      <t-tab-panel
-        wx:for="{{tabList}}"
-        wx:for-index="index"
-        wx:key="index"
-        label="{{item.text}}"
-        value="{{item.key}}"
-      />
-    </t-tabs>
+      <image class="thumb" mode="aspectFill" src="{{item.image}}" />
+      <view class="title">{{item.title}}</view>
+      <view class="desc">{{item.desc}}</view>
+    </view>
   </view>
-
-  <goods-list
-    wr-class="goods-list-container"
-    goodsList="{{goodsList}}"
-    bind:click="goodListClickHandle"
-    bind:addcart="goodListAddCartHandle"
-  />
-  <load-more list-is-empty="{{!goodsList.length}}" status="{{goodsListLoadStatus}}" bind:retry="onReTry" />
+  <view class="all-btn" bind:tap="navToSearchPage">查看全部房源</view>
   <t-toast id="t-toast" />
 </view>

--- a/pages/home/home.wxss
+++ b/pages/home/home.wxss
@@ -3,105 +3,63 @@ page {
   padding-bottom: calc(env(safe-area-inset-bottom) + 96rpx);
 }
 
-.t-tabs.t-tabs--top .t-tabs__scroll {
-  border-bottom: none !important;
-}
-
 .home-page-header {
-  background: linear-gradient(#fff, #f5f5f5);
-}
-
-.home-page-container {
-  background: #f5f5f5;
-}
-
-.home-page-container,
-.home-page-header {
-  display: block;
+  background: #ffffff;
   padding: 0 24rpx;
 }
 
-.home-page-header .t-search__input-container {
-  border-radius: 32rpx !important;
-  height: 64rpx !important;
-}
-
-.home-page-header .t-search__input {
-  font-size: 28rpx !important;
-  color: rgb(116, 116, 116) !important;
-}
-
-.home-page-header .swiper-wrap {
+.swiper-wrap {
   margin-top: 20rpx;
 }
 
-.home-page-header .t-image__swiper {
+.t-image__swiper {
   width: 100%;
   height: 300rpx;
   border-radius: 10rpx;
 }
 
-.home-page-container .t-tabs {
-  background: #f5f5f5 !important;
+.home-page-container {
+  padding: 0 24rpx 24rpx;
+  background: #f5f5f5;
 }
 
-.home-page-container .t-tabs .t-tabs-nav {
-  background-color: transparent;
-  line-height: 80rpx;
+.house-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.house-card {
+  width: 48%;
+  background: #fff;
+  margin-top: 20rpx;
+  border-radius: 8rpx;
+  overflow: hidden;
+  box-shadow: 0 2rpx 8rpx rgba(0, 0, 0, 0.06);
+}
+
+.house-card .thumb {
+  width: 100%;
+  height: 200rpx;
+}
+
+.house-card .title {
   font-size: 28rpx;
+  padding: 8rpx 12rpx 0;
   color: #333;
 }
 
-.home-page-container .t-tabs .t-tabs-scroll {
-  border: none !important;
+.house-card .desc {
+  font-size: 24rpx;
+  padding: 0 12rpx 12rpx;
+  color: #666;
 }
 
-/* 半个字 */
-.home-page-container .tab.order-nav .order-nav-item.scroll-width {
-  min-width: 165rpx;
-}
-.home-page-container .tab .order-nav-item.active {
-  color: #fa550f !important;
-}
-
-.home-page-container .tab .bottom-line {
-  border-radius: 4rpx;
-}
-
-.home-page-container .tab .order-nav-item.active .bottom-line {
-  background-color: #fa550f !important;
-}
-
-.home-page-container .tabs-external__item {
-  /* color: #666 !important; */
-  font-size: 28rpx;
-}
-
-.home-page-container .tabs-external__active {
-  color: #333333 !important;
-  font-size: 32rpx;
-}
-
-.home-page-container .tabs-external__track {
-  /* background-color: #fa4126 !important; */
-  height: 6rpx !important;
-  border-radius: 4rpx !important;
-  width: 48rpx !important;
-}
-
-.t-tabs.t-tabs--top .t-tabs__item,
-.t-tabs.t-tabs--bottom .t-tabs__item {
-  height: 86rpx !important;
-}
-
-.home-page-container .goods-list-container {
-  background: #f5f5f5 !important;
-  margin-top: 16rpx;
-}
-
-.home-page-tabs {
-  --td-tab-nav-bg-color: transparent;
-  --td-tab-border-color: transparent;
-  --td-tab-item-color: #666;
-  --td-tab-track-color: red;
+.all-btn {
+  margin-top: 20rpx;
+  background: #fa550f;
+  color: #fff;
+  text-align: center;
+  padding: 20rpx 0;
+  border-radius: 8rpx;
 }

--- a/pages/house/detail/index.js
+++ b/pages/house/detail/index.js
@@ -1,0 +1,21 @@
+import { fetchHouseDetail } from '../../../services/house/house';
+
+Page({
+  data: {
+    detail: {},
+  },
+  async init(id) {
+    const detail = await fetchHouseDetail(id);
+    this.setData({ detail });
+  },
+  onLoad(options) {
+    this.init(options.id);
+  },
+  previewImage() {
+    const { images = [] } = this.data.detail;
+    wx.previewImage({ urls: images });
+  },
+  contact() {
+    wx.navigateTo({ url: '/pages/contact/index' });
+  },
+});

--- a/pages/house/detail/index.json
+++ b/pages/house/detail/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "房源详情"
+}

--- a/pages/house/detail/index.wxml
+++ b/pages/house/detail/index.wxml
@@ -1,0 +1,13 @@
+<view class="wrap">
+  <swiper indicator-dots="true" autoplay="true" interval="3000" circular="true">
+    <swiper-item wx:for="{{detail.images}}" wx:key="index">
+      <image src="{{item}}" mode="aspectFill" bindtap="previewImage" />
+    </swiper-item>
+  </swiper>
+  <view class="info">
+    <view class="title">{{detail.title}}</view>
+    <view class="desc">{{detail.desc}}</view>
+    <view class="price">价格：请联系咨询</view>
+    <view class="action" bindtap="contact">立即联系</view>
+  </view>
+</view>

--- a/pages/house/detail/index.wxss
+++ b/pages/house/detail/index.wxss
@@ -1,0 +1,30 @@
+.wrap {
+  padding: 24rpx;
+}
+swiper {
+  width: 100%;
+  height: 300rpx;
+}
+.info .title {
+  font-size: 32rpx;
+  margin-top: 20rpx;
+  color: #333;
+}
+.info .desc {
+  font-size: 28rpx;
+  color: #666;
+  margin-top: 8rpx;
+}
+.info .price {
+  font-size: 28rpx;
+  color: #fa550f;
+  margin-top: 8rpx;
+}
+.action {
+  margin-top: 20rpx;
+  background: #fa550f;
+  color: #fff;
+  text-align: center;
+  padding: 20rpx 0;
+  border-radius: 8rpx;
+}

--- a/pages/house/list/index.js
+++ b/pages/house/list/index.js
@@ -1,0 +1,18 @@
+import { fetchHouseList } from '../../../services/house/house';
+
+Page({
+  data: {
+    list: [],
+  },
+  async init() {
+    const list = await fetchHouseList();
+    this.setData({ list });
+  },
+  onLoad() {
+    this.init();
+  },
+  handleTap(e) {
+    const { id } = e.currentTarget.dataset;
+    wx.navigateTo({ url: `/pages/house/detail/index?id=${id}` });
+  },
+});

--- a/pages/house/list/index.json
+++ b/pages/house/list/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "房源列表"
+}

--- a/pages/house/list/index.wxml
+++ b/pages/house/list/index.wxml
@@ -1,0 +1,13 @@
+<view class="list">
+  <view
+    class="item"
+    wx:for="{{list}}"
+    wx:key="id"
+    data-id="{{item.id}}"
+    bindtap="handleTap"
+  >
+    <image class="thumb" src="{{item.image}}" mode="aspectFill" />
+    <view class="title">{{item.title}}</view>
+    <view class="desc">{{item.desc}}</view>
+  </view>
+</view>

--- a/pages/house/list/index.wxss
+++ b/pages/house/list/index.wxss
@@ -1,0 +1,32 @@
+.list {
+  padding: 24rpx;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.item {
+  width: 48%;
+  background: #fff;
+  margin-top: 20rpx;
+  border-radius: 8rpx;
+  overflow: hidden;
+  box-shadow: 0 2rpx 8rpx rgba(0, 0, 0, 0.06);
+}
+
+.item .thumb {
+  width: 100%;
+  height: 200rpx;
+}
+
+.item .title {
+  font-size: 28rpx;
+  padding: 8rpx 12rpx 0;
+  color: #333;
+}
+
+.item .desc {
+  font-size: 24rpx;
+  padding: 0 12rpx 12rpx;
+  color: #666;
+}

--- a/services/house/house.js
+++ b/services/house/house.js
@@ -1,0 +1,27 @@
+import { config } from '../../config/index';
+
+function mockFetchHouseList() {
+  const { delay } = require('../_utils/delay');
+  const { getHousesList } = require('../../model/house');
+  return delay().then(() => getHousesList());
+}
+
+export function fetchHouseList() {
+  if (config.useMock) {
+    return mockFetchHouseList();
+  }
+  return Promise.resolve([]);
+}
+
+function mockFetchHouseDetail(id) {
+  const { delay } = require('../_utils/delay');
+  const { getHouseDetail } = require('../../model/house');
+  return delay().then(() => getHouseDetail(id));
+}
+
+export function fetchHouseDetail(id) {
+  if (config.useMock) {
+    return mockFetchHouseDetail(id);
+  }
+  return Promise.resolve({});
+}


### PR DESCRIPTION
## 概要
- 首页轮播图扩展到 25 张，展示房源卡片并提供查看全部按钮
- 新增房源列表、房源详情、联系客服及关于我们页面
- 引入房源 mock 数据与对应服务
- 更新 `app.json` 注册新页面

## 测试
- `npm test`（预期失败：no test specified）
- `npm run lint`（执行时报错缺少 eslint.config.js）

------
https://chatgpt.com/codex/tasks/task_e_685ce7979ae48332b018c042f557164f